### PR TITLE
Use AesUdpEncap module

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ A traffic generator built on [BESS](https://github.com/NetSys/bess).
 First, you'll need to install [BESS](https://github.com/NetSys/bess).
 
 ```
-$ git clone https://github.com/NetSys/bess.git
+$ git clone https://github.com/changlan/bess.git
+$ git checkout aes-test
 $ bess/build.py
 ```
 

--- a/generator/common.py
+++ b/generator/common.py
@@ -90,7 +90,7 @@ class TrafficSpec(object):
                  tx_cores=None, rx_cores=None, src_mac='02:1e:67:9f:4d:bb',
                  dst_mac='02:1e:67:9f:4d:bb', src_ip='192.168.0.1',
                  dst_ip='10.0.0.1', tx_timestamp_offset=0,
-                 rx_timestamp_offset=0,
+                 rx_timestamp_offset=0, timestamp=True,
                  rfc2544_loss_rate=None,
                  rfc2544_window=DEFAULT_2544_WINDOW,
                  rfc2544_warmup=DEFAULT_2544_WARMUP,
@@ -105,6 +105,7 @@ class TrafficSpec(object):
         self.dst_ip = dst_ip
         self.tx_cores = tx_cores
         self.rx_cores = rx_cores
+        self.timestamp = timestamp
         self.tx_timestamp_offset = tx_timestamp_offset
         self.rx_timestamp_offset = rx_timestamp_offset
         self.rfc2544_loss_rate = rfc2544_loss_rate
@@ -376,6 +377,10 @@ class Session(object):
     def _get_rtt(self):
         stats = {'rtt_avg': 0, 'rtt_med': 0, 'rtt_99': 0,
                  'jitter_avg': 0, 'jitter_med': 0, 'jitter_99': 0}
+
+        if not self.__spec.timestamp:
+            return stats
+
         for core, rx_pipeline in self.__rx_pipelines.items():
             measure = rx_pipeline.modules[1]
             now = measure.get_summary()

--- a/generator/common.py
+++ b/generator/common.py
@@ -64,6 +64,9 @@ def setup_mclasses(cli, globs):
         'Sink',
         'Timestamp',
         'Update',
+        'SetMetadata',
+        'AesUdpEncap',
+        'EtherEncap'
     ]
     for name in MCLASSES:
         if name in globals():

--- a/generator/common.py
+++ b/generator/common.py
@@ -66,7 +66,8 @@ def setup_mclasses(cli, globs):
         'Update',
         'SetMetadata',
         'AesUdpEncap',
-        'EtherEncap'
+        'EtherEncap',
+        'GenericDecap'
     ]
     for name in MCLASSES:
         if name in globals():

--- a/generator/gcm/gen.py
+++ b/generator/gcm/gen.py
@@ -56,6 +56,25 @@ def get_tun_payload(size, enc=True, lpriv=False):
     return payload
 
 
+def enc_packets(pcap):
+    key = 0xdeadbeefdeadbeefdeadbeefdeadbeef
+    iv = 0xcafebabecafebabecafebabe
+    eth = scapy.Ether()
+    ip = scapy.IP(src="10.0.0.1")
+    udp = scapy.UDP()
+    pkts = scapy.rdpcap(pcap)
+    new_pkts = []
+    for pkt in pkts:
+        pt = str(pkt)
+        aad = ''
+        cipher = AES_GCM(key)
+        ct, tag = cipher.encrypt(iv, pt, aad)
+        payload = long_to_bytes(iv) + long_to_bytes(tag) + ct
+        new_pkt = (eth/ip/udp/scapy.Packet(payload))
+        new_pkts.append(new_pkt)
+    return new_pkts
+
+
 if __name__ == '__main__':
     if len(sys.argv) < 2:
         print("Usage: ./gen.py <size of plaintext>")

--- a/generator/generator_commands.py
+++ b/generator/generator_commands.py
@@ -537,9 +537,12 @@ def start(cli, port, mode, spec):
             # These modules are required across all pipelines
             tx_pipe.tx_rr = RoundRobin(gates=[0])
             tx_pipe.tx_q = Queue()
-            tx_pipe.modules += [tx_pipe.tx_q,
-                                Timestamp(offset=ts.tx_timestamp_offset),
-                                tx_pipe.tx_rr]
+            if ts.timestamp:
+                tx_pipe.modules += [tx_pipe.tx_q,
+                                    Timestamp(offset=ts.tx_timestamp_offset),
+                                    tx_pipe.tx_rr]
+            else:
+                tx_pipe.modules += [tx_pipe.tx_q, tx_pipe.tx_rr]
             q = QueueOut(port=port, qid=i)
             sink = Sink()
             tx_pipe.tx_rr.connect(q, 0, 0)
@@ -598,8 +601,10 @@ def start(cli, port, mode, spec):
                 front = [q]
                 cli.bess.attach_module(q.name, wid=core)
 
-            front += [
-                Measure(offset=ts.rx_timestamp_offset, jitter_sample_prob=1.0)]
+            if ts.timestamp:
+                front += [Measure(offset=ts.rx_timestamp_offset,
+                                  jitter_sample_prob=1.0)]
+
             rx_pipe.modules = front + rx_pipe.modules
 
             rx_pipes[core] = rx_pipe

--- a/generator/modes/flowgen.py
+++ b/generator/modes/flowgen.py
@@ -48,7 +48,7 @@ class FlowGenMode(object):
         ip = scapy.IP(src=spec.src_ip, dst=spec.dst_ip)
         tcp = scapy.TCP(sport=spec.src_port, dport=12345, seq=12345)
 
-        payload = '\x65'*(spec.pkt_size - len(eth/ip/tcp))
+        payload = '\x65'*(spec.pkt_size - len(ip/tcp))
         DEFAULT_TEMPLATE = str(eth/ip/tcp/payload)
 
         if spec.flow_rate is None:

--- a/generator/modes/flowgen.py
+++ b/generator/modes/flowgen.py
@@ -76,6 +76,8 @@ class FlowGenMode(object):
                          {'name': 'udp_sport', 'size': 2, 'value_bin': '\x11\x22'},
                          {'name': 'udp_dport', 'size': 2, 'value_bin': '\x33\x44'}]),
             AesUdpEncap(),
+            # Random destination port
+            RandomUpdate(fields=[{'offset': 22, 'size': 2, 'min': 0x0400, 'max': 0xffff}]),
             EtherEncap(),
             IPChecksum()
         ])

--- a/generator/modes/flowgen.py
+++ b/generator/modes/flowgen.py
@@ -44,11 +44,12 @@ class FlowGenMode(object):
     @staticmethod
     def setup_tx_pipeline(cli, port, spec):
         setup_mclasses(cli, globals())
+        eth = scapy.Ether()
         ip = scapy.IP(src=spec.src_ip, dst=spec.dst_ip)
         tcp = scapy.TCP(sport=spec.src_port, dport=12345, seq=12345)
 
-        payload = '\x65'*(spec.pkt_size - len(ip/tcp))
-        DEFAULT_TEMPLATE = str(ip/tcp/payload)
+        payload = '\x65'*(spec.pkt_size - len(eth/ip/tcp))
+        DEFAULT_TEMPLATE = str(eth/ip/tcp/payload)
 
         if spec.flow_rate is None:
             spec.flow_rate = spec.num_flows / spec.flow_duration
@@ -74,6 +75,7 @@ class FlowGenMode(object):
                          {'name': 'ip_dst', 'size': 4, 'value_bin': aton('10.0.10.2')},
                          {'name': 'udp_sport', 'size': 2, 'value_bin': '\x11\x22'},
                          {'name': 'udp_dport', 'size': 2, 'value_bin': '\x33\x44'}]),
+            GenericDecap(bytes=14),
             AesUdpEncap(),
             # Random destination port
             RandomUpdate(fields=[{'offset': 22, 'size': 2, 'min': 0x0400, 'max': 0xffff}]),

--- a/generator/modes/flowgen.py
+++ b/generator/modes/flowgen.py
@@ -44,11 +44,10 @@ class FlowGenMode(object):
     @staticmethod
     def setup_tx_pipeline(cli, port, spec):
         setup_mclasses(cli, globals())
-        eth = scapy.Ether(src=spec.src_mac, dst=spec.dst_mac)
         ip = scapy.IP(src=spec.src_ip, dst=spec.dst_ip)
         tcp = scapy.TCP(sport=spec.src_port, dport=12345, seq=12345)
 
-        payload = '\x65'*(spec.pkt_size - len(eth/ip/tcp))
+        payload = '\x65'*(spec.pkt_size - len(ip/tcp))
         DEFAULT_TEMPLATE = str(ip/tcp/payload)
 
         if spec.flow_rate is None:

--- a/parsepcap.py
+++ b/parsepcap.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+
+from generator.gcm.gen import *
+import sys
+import scapy.all as scapy
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2 :
+        print("Usage: ./parsepcap.py <pcap>")
+        exit(0)
+
+    pcap = sys.argv[1]
+    name = "out.pcap"
+    enc_pkts = enc_packets(pcap)
+    scapy.wrpcap(name, enc_pkts)


### PR DESCRIPTION
Encrypt and encapsulate IP packets in UDP/IP headers using AES-GCM-128. The format of the payload is: IV (12 bytes) + Tag (16 bytes) + Cipher text. 

The values of key and IV are defined in https://github.com/changlan/bess/blob/5ce22c921431481fc911aede3a32c59303fd2562/core/modules/aes_udp_encap.cc#L70